### PR TITLE
Set gradle build heap size to avoid build failure

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@
 jmhOutputPath=build/reports/jmh/human-readable-output.txt
 jmhIncludeRegex=.*
 org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx768m


### PR DESCRIPTION
Set gradle build heap size to avoid build failure because JVM heap space is exhausted.